### PR TITLE
Remove copying of default profiles to plugins dir, no need with using CMRC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,6 @@ CONFIGURE_FILE( "infoTemplate.info.in" "${PROJECT_NAME}.info" )
 
 #Set the relative directory where the plugin should be located
 SET( PLUGIN_RELATIVE_DIR "plugins/cpp/piip/${PROJECT_NAME}" )
-#Add to preprocessor definitions
-ADD_DEFINITIONS( -DPLUGIN_RELATIVE_DIR=${PLUGIN_RELATIVE_DIR} )
 
 # Set the install destination directory
 IF( NOT PLUGIN_DESTINATION_DIR )
@@ -111,11 +109,6 @@ IF( ${SEDEEN_FOUND} )
   INSTALL(TARGETS ${PROJECT_NAME}
           LIBRARY DESTINATION "${PLUGIN_DESTINATION_DIR}")
   INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.info"
-          DESTINATION "${PLUGIN_DESTINATION_DIR}")
-  INSTALL(FILES "defaultprofiles/HematoxylinPEosinSample.xml"
-                "defaultprofiles/HematoxylinPEosinFromRJ.xml"
-                "defaultprofiles/HematoxylinPDABFromRJ.xml"
-                "defaultprofiles/HematoxylinPEosinPDABFromRJ.xml"
           DESTINATION "${PLUGIN_DESTINATION_DIR}")
 ENDIF()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,14 @@ IF(NOT BOOST_VERSION)
 ENDIF()
 FIND_PACKAGE(Boost ${BOOST_VERSION} )
 
+INCLUDE(cmake/CMakeRC.cmake)
+
+cmrc_add_resource_library(stain-resources ALIAS stain::rc NAMESPACE stain
+  defaultprofiles/HematoxylinPDABFromRJ.xml
+  defaultprofiles/HematoxylinPEosinFromRJ.xml
+  defaultprofiles/HematoxylinPEosinPDABFromRJ.xml
+  defaultprofiles/HematoxylinPEosinSample.xml)
+
 # Fetch TinyXML2 files. Do not build as a subproject
 FetchContent_Declare(
   TinyXML2
@@ -76,6 +84,7 @@ ADD_LIBRARY( ${PROJECT_NAME} MODULE
 
 # Link the library against the Sedeen SDK libraries
 TARGET_LINK_LIBRARIES( ${PROJECT_NAME} ${SEDEENSDK_LIBRARIES} )
+TARGET_LINK_LIBRARIES( ${PROJECT_NAME} stain::rc )
 
 #Create or update the .info file in the build directory
 STRING( TIMESTAMP DATE_CREATED_TEXT "%Y-%m-%d" )

--- a/StainAnalysis-plugin.cpp
+++ b/StainAnalysis-plugin.cpp
@@ -71,7 +71,6 @@ StainAnalysis::StainAnalysis()
     m_stainToDisplay(),
     m_applyThreshold(),
     m_threshold(),
-    m_pathToPlugin(""),
     m_result(),
     m_outputText(),
     m_report(""),

--- a/StainAnalysis-plugin.cpp
+++ b/StainAnalysis-plugin.cpp
@@ -46,6 +46,10 @@
 #include "image/io/Image.h"
 #include "image/tile/Factory.h"
 
+#include <cmrc/cmrc.hpp>
+
+CMRC_DECLARE(stain);
+
 // Poco header needed for the macros below
 #include <Poco/ClassLibrary.h>
 
@@ -75,28 +79,16 @@ StainAnalysis::StainAnalysis()
     m_thresholdMaxVal(300.0),
     m_colorDeconvolution_factory(nullptr)
 {
-    //Get the path of the current plugin
-    sedeen::file::Location pluginLocation = sedeen::file::getWorkingDirectory();
-    if (GetPluginRelativeDirectory() != "PLUGIN_RELATIVE_DIR-NOTFOUND") {
-        //Convert to std::filesystem::path type, and use the path concatenation operator
-        m_pathToPlugin = std::filesystem::path(pluginLocation.getFilename()) / GetPluginRelativeDirectory();
-        //Build the list of stain vector file names
-        m_stainProfileFullPathNames.push_back(""); //Leave a blank place for the loaded file
-        //HematoxylinPEosinSample
-        m_stainProfileFullPathNames.push_back(m_pathToPlugin / HematoxylinPEosinSampleFilename());
-        //HematoxylinPEosin from Ruifrok and Johnston
-        m_stainProfileFullPathNames.push_back(m_pathToPlugin / HematoxylinPEosinFromRJFilename());
-        //HematoxylinPDAB from Ruifrok and Johnston
-        m_stainProfileFullPathNames.push_back(m_pathToPlugin / HematoxylinPDABFromRJFilename());
-        //HematoxylinPEosinPDAB from Ruifrok and Johnston
-        m_stainProfileFullPathNames.push_back(m_pathToPlugin / HematoxylinPEosinPDABFromRJFilename());        
-    }
-    else { //Could not get the plugin's relative directory
-        //Location of the default stain profiles is unknown
-        m_pathToPlugin = "";
-        //Do not try to load the default stain profiles
-        m_stainProfileFullPathNames.push_back("");
-    }
+    // Build the list of stain vector file names
+    m_stainProfileFullPathNames.push_back("");  // Leave a blank place for the loaded file
+    // HematoxylinPEosinSample
+    m_stainProfileFullPathNames.push_back(HematoxylinPEosinSampleFilename());
+    // HematoxylinPEosin from Ruifrok and Johnston
+    m_stainProfileFullPathNames.push_back(HematoxylinPEosinFromRJFilename());
+    // HematoxylinPDAB from Ruifrok and Johnston
+    m_stainProfileFullPathNames.push_back(HematoxylinPDABFromRJFilename());
+    // HematoxylinPEosinPDAB from Ruifrok and Johnston
+    m_stainProfileFullPathNames.push_back(HematoxylinPEosinPDABFromRJFilename());
 
     //Create stain vector profiles for the loaded and default profiles, push to vector
     //Loaded
@@ -107,18 +99,20 @@ StainAnalysis::StainAnalysis()
     for (auto it = m_stainProfileFullPathNames.begin()+1; it != m_stainProfileFullPathNames.end(); ++it) {
         std::shared_ptr<StainProfile> tsp = std::make_shared<StainProfile>();
         //Convert path to string, read stain profile, and check whether the read was successful
-        bool success = tsp->readStainProfile((*it).generic_string());
-        if (success) {
+        auto const fs = cmrc::stain::get_filesystem();
+        if (auto const is_file = fs.is_file((*it).generic_string())) {
+          auto const file = fs.open((*it).generic_string());
+          if (tsp->readStainProfile(file.begin(), file.size())) {
             m_stainProfileList.push_back(tsp);
-            //Get the name of the profile
+            // Get the name of the profile
             m_stainVectorProfileOptions.push_back(tsp->GetNameOfStainProfile());
+            continue;
+          }
         }
-        else {
-            //make a dummy one
-            m_stainProfileList.push_back(std::make_shared<StainProfile>());
-            m_stainVectorProfileOptions.push_back("Profile failed to load");
-        }
-        tsp.reset();
+
+        // make a dummy one
+        m_stainProfileList.push_back(std::make_shared<StainProfile>());
+        m_stainVectorProfileOptions.push_back("Profile failed to load");
     }
 
     //Define the default list of names of stains to display

--- a/StainAnalysis-plugin.h
+++ b/StainAnalysis-plugin.h
@@ -28,12 +28,6 @@
 //Convert a macro defined in CMake to a string
 #define StringLiteral(stl) #stl
 #define MacroToString(macro) StringLiteral(macro)
-//Specifically, convert PLUGIN_RELATIVE_DIR to a string literal
-#ifndef PLUGIN_RELATIVE_DIR
-#define PLUGIN_RELATIVE_DIR_STRING "PLUGIN_RELATIVE_DIR-NOTFOUND"
-#else
-#define PLUGIN_RELATIVE_DIR_STRING MacroToString(PLUGIN_RELATIVE_DIR)
-#endif
 
 #include "algorithm/AlgorithmBase.h"
 #include "algorithm/Parameters.h"
@@ -98,9 +92,6 @@ private:
 
     ///Access the member file dialog parameter, if possible load the stain profile, return true on success
     bool LoadStainProfileFromFileDialog();
-
-    ///std::filesystem::path type to the plugin's directory
-    std::filesystem::path m_pathToPlugin;
 
     ///List of the full path file names of the stain profiles
     std::vector<std::filesystem::path> m_stainProfileFullPathNames;

--- a/StainAnalysis-plugin.h
+++ b/StainAnalysis-plugin.h
@@ -91,12 +91,10 @@ private:
 
 private:
     ///Names of the default stain profile files
-    inline static const std::string HematoxylinPEosinSampleFilename()     { return "HematoxylinPEosinSample.xml"; }
-    inline static const std::string HematoxylinPEosinFromRJFilename()     { return "HematoxylinPEosinFromRJ.xml"; }
-    inline static const std::string HematoxylinPDABFromRJFilename()       { return "HematoxylinPDABFromRJ.xml"; }
-    inline static const std::string HematoxylinPEosinPDABFromRJFilename() { return "HematoxylinPEosinPDABFromRJ.xml"; }
-    ///Returns the directory of the plugin relative to the Sedeen Viewer directory as a string
-    inline static const std::filesystem::path GetPluginRelativeDirectory() { return std::filesystem::path(PLUGIN_RELATIVE_DIR_STRING); }
+    inline static const std::string HematoxylinPEosinSampleFilename()     { return "defaultprofiles/HematoxylinPEosinSample.xml"; }
+    inline static const std::string HematoxylinPEosinFromRJFilename()     { return "defaultprofiles/HematoxylinPEosinFromRJ.xml"; }
+    inline static const std::string HematoxylinPDABFromRJFilename()       { return "defaultprofiles/HematoxylinPDABFromRJ.xml"; }
+    inline static const std::string HematoxylinPEosinPDABFromRJFilename() { return "defaultprofiles/HematoxylinPEosinPDABFromRJ.xml"; }
 
     ///Access the member file dialog parameter, if possible load the stain profile, return true on success
     bool LoadStainProfileFromFileDialog();

--- a/StainProfile.cpp
+++ b/StainProfile.cpp
@@ -547,7 +547,7 @@ bool StainProfile::readStainProfile(std::string fileString) {
         return false;
     }
     else {
-        tinyxml2::XMLError eResult = this->readStainProfileFromXML(fileString);
+        tinyxml2::XMLError eResult = this->readStainProfileFromXMLFile(fileString);
         if (eResult == tinyxml2::XML_SUCCESS) {
             return true;
         }
@@ -558,6 +558,16 @@ bool StainProfile::readStainProfile(std::string fileString) {
     return false;
 }//end readStainProfile
 
+/// Public read method, calls private write method
+bool StainProfile::readStainProfile(const char *str, size_t size) {
+    tinyxml2::XMLError eResult = this->readStainProfileFromXMLString(str, size);
+    if (eResult == tinyxml2::XML_SUCCESS) {
+      return true;
+    } else {
+      return false;
+    }
+}  // end readStainProfile
+
 ///Private write method that deals with TinyXML2
 tinyxml2::XMLError StainProfile::writeStainProfileToXML(std::string fileString) {
     //Write it!
@@ -567,7 +577,7 @@ tinyxml2::XMLError StainProfile::writeStainProfileToXML(std::string fileString) 
     return tinyxml2::XML_SUCCESS;
 }//end writeStainProfileToXML
 
-tinyxml2::XMLError StainProfile::readStainProfileFromXML(std::string fileString) {
+tinyxml2::XMLError StainProfile::readStainProfileFromXMLFile(std::string fileString) {
     //Clear the current structure
     bool clearSuccessful = ClearXMLDocument();
     if (!clearSuccessful) {
@@ -577,8 +587,26 @@ tinyxml2::XMLError StainProfile::readStainProfileFromXML(std::string fileString)
     //Read it!
     tinyxml2::XMLError eResult = this->GetXMLDoc()->LoadFile(fileString.c_str());
     XMLCheckResult(eResult);
-    //else
-    //Assign the member pointers to children in the loaded data structure
+
+    return parseXMLDoc();
+}//end readStainProfileFromXMLFile
+
+tinyxml2::XMLError StainProfile::readStainProfileFromXMLString(const char *str, size_t size) {
+  // Clear the current structure
+  bool clearSuccessful = ClearXMLDocument();
+  if (!clearSuccessful) {
+    return tinyxml2::XML_ERROR_PARSING_ELEMENT;
+  }
+  // else
+  // Read it!
+  tinyxml2::XMLError eResult = this->GetXMLDoc()->Parse(str, size);
+  XMLCheckResult(eResult);
+
+  return parseXMLDoc();
+}  // end readStainProfileFromXMLFile
+
+tinyxml2::XMLError StainProfile::parseXMLDoc() {
+    // Assign the member pointers to children in the loaded data structure
     m_rootElement = this->GetXMLDoc()->FirstChildElement(rootTag());
     if (m_rootElement == nullptr) {
         return tinyxml2::XML_ERROR_PARSING_ELEMENT;
@@ -588,24 +616,24 @@ tinyxml2::XMLError StainProfile::readStainProfileFromXML(std::string fileString)
         return tinyxml2::XML_ERROR_PARSING_ELEMENT;
     }
 
-    tinyxml2::XMLElement* tempStain = m_componentsElement->FirstChildElement(stainTag());
+    tinyxml2::XMLElement *tempStain =
+        m_componentsElement->FirstChildElement(stainTag());
     while (tempStain != nullptr) {
-        //They must all have an index, or it should be considered an error
+        // They must all have an index, or it should be considered an error
         int stainIndex(-1);
-        tinyxml2::XMLError eResult = tempStain->QueryIntAttribute(indexOfStainAttribute(), &stainIndex);
+        tinyxml2::XMLError eResult =
+            tempStain->QueryIntAttribute(indexOfStainAttribute(), &stainIndex);
         XMLCheckResult(eResult);
-        //Choose which stain element to assign tempStain to
+        // Choose which stain element to assign tempStain to
         if (stainIndex == 1) {
             m_stainOneElement = tempStain;
-        }
-        else if (stainIndex == 2) {
+        } else if (stainIndex == 2) {
             m_stainTwoElement = tempStain;
-        }
-        else if (stainIndex == 3) {
+        } else if (stainIndex == 3) {
             m_stainThreeElement = tempStain;
         }
-        //tempStain is just a pointer to an existing element
-        //Dropping it does not create a memory leak
+        // tempStain is just a pointer to an existing element
+        // Dropping it does not create a memory leak
         tempStain = tempStain->NextSiblingElement(stainTag());
     }
 
@@ -615,12 +643,12 @@ tinyxml2::XMLError StainProfile::readStainProfileFromXML(std::string fileString)
     }
     m_parameterElement = m_algorithmElement->FirstChildElement(parameterTag());
     if (m_parameterElement == nullptr) {
-        //do nothing, for now. The only separation algorithm has no parameters
-        //return tinyxml2::XML_ERROR_PARSING_ELEMENT;
+      // do nothing, for now. The only separation algorithm has no parameters
+      // return tinyxml2::XML_ERROR_PARSING_ELEMENT;
     }
 
     return tinyxml2::XML_SUCCESS;
-}//end readStainProfileFromXML
+}//end parseXMLDoc
 
 std::vector<std::string> StainProfile::GetStainSeparationAlgorithmOptions() {
     return m_stainSeparationAlgorithmOptions;

--- a/StainProfile.h
+++ b/StainProfile.h
@@ -111,6 +111,8 @@ public:
     bool writeStainProfile(std::string);
     ///Public read method - checks file existence first, returns true/false for success/failure
     bool readStainProfile(std::string);
+    /// Public read method - reads profile from embedded resource
+    bool readStainProfile(const char *, size_t);
 
     ///Request the list of possible stain separation algorithm names from the class, static defined in constructor
     std::vector<std::string> GetStainSeparationAlgorithmOptions();
@@ -172,7 +174,11 @@ private:
     ///If file is able to be opened, write the current stain profile to file as XML
     tinyxml2::XMLError writeStainProfileToXML(std::string);
     ///If file is able to be opened, read from an XML file and fill variables in this class
-    tinyxml2::XMLError readStainProfileFromXML(std::string);
+    tinyxml2::XMLError readStainProfileFromXMLFile(std::string);
+    ///Read a stain profile from a string
+    tinyxml2::XMLError readStainProfileFromXMLString(const char *, size_t);
+    //Parse XML document
+    tinyxml2::XMLError parseXMLDoc();
 
 private:
     ///Store the list of possible stain separation algorithm names here

--- a/cmake/CMakeRC.cmake
+++ b/cmake/CMakeRC.cmake
@@ -1,0 +1,617 @@
+# This block is executed when generating an intermediate resource file, not when
+# running in CMake configure mode
+if(_CMRC_GENERATE_MODE)
+    # Read in the digits
+    file(READ "${INPUT_FILE}" bytes HEX)
+    # Format each pair into a character literal. Heuristics seem to favor doing
+    # the conversion in groups of five for fastest conversion
+    string(REGEX REPLACE "(..)(..)(..)(..)(..)" "'\\\\x\\1','\\\\x\\2','\\\\x\\3','\\\\x\\4','\\\\x\\5'," chars "${bytes}")
+    # Since we did this in groups, we have some leftovers to clean up
+    string(LENGTH "${bytes}" n_bytes2)
+    math(EXPR n_bytes "${n_bytes2} / 2")
+    math(EXPR remainder "${n_bytes} % 5") # <-- '5' is the grouping count from above
+    set(cleanup_re "$")
+    set(cleanup_sub )
+    while(remainder)
+        set(cleanup_re "(..)${cleanup_re}")
+        set(cleanup_sub "'\\\\x\\${remainder}',${cleanup_sub}")
+        math(EXPR remainder "${remainder} - 1")
+    endwhile()
+    if(NOT cleanup_re STREQUAL "$")
+        string(REGEX REPLACE "${cleanup_re}" "${cleanup_sub}" chars "${chars}")
+    endif()
+    string(CONFIGURE [[
+        namespace { const char file_array[] = { @chars@ 0 }; }
+        namespace cmrc { namespace @NAMESPACE@ { namespace res_chars {
+        extern const char* const @SYMBOL@_begin = file_array;
+        extern const char* const @SYMBOL@_end = file_array + @n_bytes@;
+        }}}
+    ]] code)
+    file(WRITE "${OUTPUT_FILE}" "${code}")
+    # Exit from the script. Nothing else needs to be processed
+    return()
+endif()
+
+set(_version 2.0.0)
+
+cmake_minimum_required(VERSION 3.3)
+include(CMakeParseArguments)
+
+if(COMMAND cmrc_add_resource_library)
+    if(NOT DEFINED _CMRC_VERSION OR NOT (_version STREQUAL _CMRC_VERSION))
+        message(WARNING "More than one CMakeRC version has been included in this project.")
+    endif()
+    # CMakeRC has already been included! Don't do anything
+    return()
+endif()
+
+set(_CMRC_VERSION "${_version}" CACHE INTERNAL "CMakeRC version. Used for checking for conflicts")
+
+set(_CMRC_SCRIPT "${CMAKE_CURRENT_LIST_FILE}" CACHE INTERNAL "Path to CMakeRC script")
+
+function(_cmrc_normalize_path var)
+    set(path "${${var}}")
+    file(TO_CMAKE_PATH "${path}" path)
+    while(path MATCHES "//")
+        string(REPLACE "//" "/" path "${path}")
+    endwhile()
+    string(REGEX REPLACE "/+$" "" path "${path}")
+    set("${var}" "${path}" PARENT_SCOPE)
+endfunction()
+
+get_filename_component(_inc_dir "${CMAKE_BINARY_DIR}/_cmrc/include" ABSOLUTE)
+set(CMRC_INCLUDE_DIR "${_inc_dir}" CACHE INTERNAL "Directory for CMakeRC include files")
+# Let's generate the primary include file
+file(MAKE_DIRECTORY "${CMRC_INCLUDE_DIR}/cmrc")
+set(hpp_content [==[
+#ifndef CMRC_CMRC_HPP_INCLUDED
+#define CMRC_CMRC_HPP_INCLUDED
+
+#include <cassert>
+#include <functional>
+#include <iterator>
+#include <list>
+#include <map>
+#include <mutex>
+#include <string>
+#include <system_error>
+#include <type_traits>
+
+namespace cmrc { namespace detail { struct dummy; } }
+
+#define CMRC_DECLARE(libid) \
+    namespace cmrc { namespace detail { \
+    struct dummy; \
+    static_assert(std::is_same<dummy, ::cmrc::detail::dummy>::value, "CMRC_DECLARE() must only appear at the global namespace"); \
+    } } \
+    namespace cmrc { namespace libid { \
+    cmrc::embedded_filesystem get_filesystem(); \
+    } } static_assert(true, "")
+
+namespace cmrc {
+
+class file {
+    const char* _begin = nullptr;
+    const char* _end = nullptr;
+
+public:
+    using iterator = const char*;
+    using const_iterator = iterator;
+    iterator begin() const noexcept { return _begin; }
+    iterator cbegin() const noexcept { return _begin; }
+    iterator end() const noexcept { return _end; }
+    iterator cend() const noexcept { return _end; }
+    std::size_t size() const { return std::distance(begin(), end()); }
+
+    file() = default;
+    file(iterator beg, iterator end) noexcept : _begin(beg), _end(end) {}
+};
+
+class directory_entry;
+
+namespace detail {
+
+class directory;
+class file_data;
+
+class file_or_directory {
+    union _data_t {
+        class file_data* file_data;
+        class directory* directory;
+    } _data;
+    bool _is_file = true;
+
+public:
+    explicit file_or_directory(file_data& f) {
+        _data.file_data = &f;
+    }
+    explicit file_or_directory(directory& d) {
+        _data.directory = &d;
+        _is_file = false;
+    }
+    bool is_file() const noexcept {
+        return _is_file;
+    }
+    bool is_directory() const noexcept {
+        return !is_file();
+    }
+    const directory& as_directory() const noexcept {
+        assert(!is_file());
+        return *_data.directory;
+    }
+    const file_data& as_file() const noexcept {
+        assert(is_file());
+        return *_data.file_data;
+    }
+};
+
+class file_data {
+public:
+    const char* begin_ptr;
+    const char* end_ptr;
+    file_data(const file_data&) = delete;
+    file_data(const char* b, const char* e) : begin_ptr(b), end_ptr(e) {}
+};
+
+inline std::pair<std::string, std::string> split_path(const std::string& path) {
+    auto first_sep = path.find("/");
+    if (first_sep == path.npos) {
+        return std::make_pair(path, "");
+    } else {
+        return std::make_pair(path.substr(0, first_sep), path.substr(first_sep + 1));
+    }
+}
+
+struct created_subdirectory {
+    class directory& directory;
+    class file_or_directory& index_entry;
+};
+
+class directory {
+    std::list<file_data> _files;
+    std::list<directory> _dirs;
+    std::map<std::string, file_or_directory> _index;
+
+    using base_iterator = std::map<std::string, file_or_directory>::const_iterator;
+
+public:
+
+    directory() = default;
+    directory(const directory&) = delete;
+
+    created_subdirectory add_subdir(std::string name) & {
+        _dirs.emplace_back();
+        auto& back = _dirs.back();
+        auto& fod = _index.emplace(name, file_or_directory{back}).first->second;
+        return created_subdirectory{back, fod};
+    }
+
+    file_or_directory* add_file(std::string name, const char* begin, const char* end) & {
+        assert(_index.find(name) == _index.end());
+        _files.emplace_back(begin, end);
+        return &_index.emplace(name, file_or_directory{_files.back()}).first->second;
+    }
+
+    const file_or_directory* get(const std::string& path) const {
+        auto pair = split_path(path);
+        auto child = _index.find(pair.first);
+        if (child == _index.end()) {
+            return nullptr;
+        }
+        auto& entry  = child->second;
+        if (pair.second.empty()) {
+            // We're at the end of the path
+            return &entry;
+        }
+
+        if (entry.is_file()) {
+            // We can't traverse into a file. Stop.
+            return nullptr;
+        }
+        // Keep going down
+        return entry.as_directory().get(pair.second);
+    }
+
+    class iterator {
+        base_iterator _base_iter;
+        base_iterator _end_iter;
+    public:
+        using value_type = directory_entry;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const value_type*;
+        using reference = const value_type&;
+        using iterator_category = std::input_iterator_tag;
+
+        iterator() = default;
+        explicit iterator(base_iterator iter, base_iterator end) : _base_iter(iter), _end_iter(end) {}
+
+        iterator begin() const noexcept {
+            return *this;
+        }
+
+        iterator end() const noexcept {
+            return iterator(_end_iter, _end_iter);
+        }
+
+        inline value_type operator*() const noexcept;
+
+        bool operator==(const iterator& rhs) const noexcept {
+            return _base_iter == rhs._base_iter;
+        }
+
+        bool operator!=(const iterator& rhs) const noexcept {
+            return !(*this == rhs);
+        }
+
+        iterator operator++() noexcept {
+            auto cp = *this;
+            ++_base_iter;
+            return cp;
+        }
+
+        iterator& operator++(int) noexcept {
+            ++_base_iter;
+            return *this;
+        }
+    };
+
+    using const_iterator = iterator;
+
+    iterator begin() const noexcept {
+        return iterator(_index.begin(), _index.end());
+    }
+
+    iterator end() const noexcept {
+        return iterator();
+    }
+};
+
+inline std::string normalize_path(std::string path) {
+    while (path.find("/") == 0) {
+        path.erase(path.begin());
+    }
+    while (!path.empty() && (path.rfind("/") == path.size() - 1)) {
+        path.pop_back();
+    }
+    auto off = path.npos;
+    while ((off = path.find("//")) != path.npos) {
+        path.erase(path.begin() + off);
+    }
+    return path;
+}
+
+using index_type = std::map<std::string, const cmrc::detail::file_or_directory*>;
+
+} // detail
+
+class directory_entry {
+    std::string _fname;
+    const detail::file_or_directory* _item;
+
+public:
+    directory_entry() = delete;
+    explicit directory_entry(std::string filename, const detail::file_or_directory& item)
+        : _fname(filename)
+        , _item(&item)
+    {}
+
+    const std::string& filename() const & {
+        return _fname;
+    }
+    std::string filename() const && {
+        return std::move(_fname);
+    }
+
+    bool is_file() const {
+        return _item->is_file();
+    }
+
+    bool is_directory() const {
+        return _item->is_directory();
+    }
+};
+
+directory_entry detail::directory::iterator::operator*() const noexcept {
+    assert(begin() != end());
+    return directory_entry(_base_iter->first, _base_iter->second);
+}
+
+using directory_iterator = detail::directory::iterator;
+
+class embedded_filesystem {
+    // Never-null:
+    const cmrc::detail::index_type* _index;
+    const detail::file_or_directory* _get(std::string path) const {
+        path = detail::normalize_path(path);
+        auto found = _index->find(path);
+        if (found == _index->end()) {
+            return nullptr;
+        } else {
+            return found->second;
+        }
+    }
+
+public:
+    explicit embedded_filesystem(const detail::index_type& index)
+        : _index(&index)
+    {}
+
+    file open(const std::string& path) const {
+        auto entry_ptr = _get(path);
+        if (!entry_ptr || !entry_ptr->is_file()) {
+            throw std::system_error(make_error_code(std::errc::no_such_file_or_directory), path);
+        }
+        auto& dat = entry_ptr->as_file();
+        return file{dat.begin_ptr, dat.end_ptr};
+    }
+
+    bool is_file(const std::string& path) const noexcept {
+        auto entry_ptr = _get(path);
+        return entry_ptr && entry_ptr->is_file();
+    }
+
+    bool is_directory(const std::string& path) const noexcept {
+        auto entry_ptr = _get(path);
+        return entry_ptr && entry_ptr->is_directory();
+    }
+
+    bool exists(const std::string& path) const noexcept {
+        return !!_get(path);
+    }
+
+    directory_iterator iterate_directory(const std::string& path) const {
+        auto entry_ptr = _get(path);
+        if (!entry_ptr) {
+            throw std::system_error(make_error_code(std::errc::no_such_file_or_directory), path);
+        }
+        if (!entry_ptr->is_directory()) {
+            throw std::system_error(make_error_code(std::errc::not_a_directory), path);
+        }
+        return entry_ptr->as_directory().begin();
+    }
+};
+
+}
+
+#endif // CMRC_CMRC_HPP_INCLUDED
+]==])
+
+set(cmrc_hpp "${CMRC_INCLUDE_DIR}/cmrc/cmrc.hpp" CACHE INTERNAL "")
+set(_generate 1)
+if(EXISTS "${cmrc_hpp}")
+    file(READ "${cmrc_hpp}" _current)
+    if(_current STREQUAL hpp_content)
+        set(_generate 0)
+    endif()
+endif()
+file(GENERATE OUTPUT "${cmrc_hpp}" CONTENT "${hpp_content}" CONDITION ${_generate})
+
+add_library(cmrc-base INTERFACE)
+target_include_directories(cmrc-base INTERFACE "${CMRC_INCLUDE_DIR}")
+# Signal a basic C++11 feature to require C++11.
+target_compile_features(cmrc-base INTERFACE cxx_nullptr)
+set_property(TARGET cmrc-base PROPERTY INTERFACE_CXX_EXTENSIONS OFF)
+add_library(cmrc::base ALIAS cmrc-base)
+
+function(cmrc_add_resource_library name)
+    set(args ALIAS NAMESPACE)
+    cmake_parse_arguments(ARG "" "${args}" "" "${ARGN}")
+    # Generate the identifier for the resource library's namespace
+    set(ns_re "[a-zA-Z_][a-zA-Z0-9_]*")
+    if(NOT DEFINED ARG_NAMESPACE)
+        # Check that the library name is also a valid namespace
+        if(NOT name MATCHES "${ns_re}")
+            message(SEND_ERROR "Library name is not a valid namespace. Specify the NAMESPACE argument")
+        endif()
+        set(ARG_NAMESPACE "${name}")
+    else()
+        if(NOT ARG_NAMESPACE MATCHES "${ns_re}")
+            message(SEND_ERROR "NAMESPACE for ${name} is not a valid C++ namespace identifier (${ARG_NAMESPACE})")
+        endif()
+    endif()
+    set(libname "${name}")
+    # Generate a library with the compiled in character arrays.
+    string(CONFIGURE [=[
+        #include <cmrc/cmrc.hpp>
+        #include <map>
+        #include <utility>
+
+        namespace cmrc {
+        namespace @ARG_NAMESPACE@ {
+
+        namespace res_chars {
+        // These are the files which are available in this resource library
+        $<JOIN:$<TARGET_PROPERTY:@libname@,CMRC_EXTERN_DECLS>,
+        >
+        }
+
+        namespace {
+
+        const cmrc::detail::index_type&
+        get_root_index() {
+            static cmrc::detail::directory root_directory_;
+            static cmrc::detail::file_or_directory root_directory_fod{root_directory_};
+            static cmrc::detail::index_type root_index;
+            root_index.emplace("", &root_directory_fod);
+            struct dir_inl {
+                class cmrc::detail::directory& directory;
+            };
+            dir_inl root_directory_dir{root_directory_};
+            (void)root_directory_dir;
+            $<JOIN:$<TARGET_PROPERTY:@libname@,CMRC_MAKE_DIRS>,
+            >
+            $<JOIN:$<TARGET_PROPERTY:@libname@,CMRC_MAKE_FILES>,
+            >
+            return root_index;
+        }
+
+        }
+
+        cmrc::embedded_filesystem get_filesystem() {
+            static auto& index = get_root_index();
+            return cmrc::embedded_filesystem{index};
+        }
+
+        } // @ARG_NAMESPACE@
+        } // cmrc
+    ]=] cpp_content @ONLY)
+    get_filename_component(libdir "${CMAKE_CURRENT_BINARY_DIR}/__cmrc_${name}" ABSOLUTE)
+    get_filename_component(lib_tmp_cpp "${libdir}/lib_.cpp" ABSOLUTE)
+    string(REPLACE "\n        " "\n" cpp_content "${cpp_content}")
+    file(GENERATE OUTPUT "${lib_tmp_cpp}" CONTENT "${cpp_content}")
+    get_filename_component(libcpp "${libdir}/lib.cpp" ABSOLUTE)
+    add_custom_command(OUTPUT "${libcpp}"
+        DEPENDS "${lib_tmp_cpp}" "${cmrc_hpp}"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${lib_tmp_cpp}" "${libcpp}"
+        COMMENT "Generating ${name} resource loader"
+        )
+    # Generate the actual static library. Each source file is just a single file
+    # with a character array compiled in containing the contents of the
+    # corresponding resource file.
+    add_library(${name} STATIC ${libcpp})
+    set_property(TARGET ${name} PROPERTY CMRC_LIBDIR "${libdir}")
+    set_property(TARGET ${name} PROPERTY CMRC_NAMESPACE "${ARG_NAMESPACE}")
+    target_link_libraries(${name} PUBLIC cmrc::base)
+    set_property(TARGET ${name} PROPERTY CMRC_IS_RESOURCE_LIBRARY TRUE)
+    if(ARG_ALIAS)
+        add_library("${ARG_ALIAS}" ALIAS ${name})
+    endif()
+    cmrc_add_resources(${name} ${ARG_UNPARSED_ARGUMENTS})
+endfunction()
+
+function(_cmrc_register_dirs name dirpath)
+    if(dirpath STREQUAL "")
+        return()
+    endif()
+    # Skip this dir if we have already registered it
+    get_target_property(registered "${name}" _CMRC_REGISTERED_DIRS)
+    if(dirpath IN_LIST registered)
+        return()
+    endif()
+    # Register the parent directory first
+    get_filename_component(parent "${dirpath}" DIRECTORY)
+    if(NOT parent STREQUAL "")
+        _cmrc_register_dirs("${name}" "${parent}")
+    endif()
+    # Now generate the registration
+    set_property(TARGET "${name}" APPEND PROPERTY _CMRC_REGISTERED_DIRS "${dirpath}")
+    _cm_encode_fpath(sym "${dirpath}")
+    if(parent STREQUAL "")
+        set(parent_sym root_directory)
+    else()
+        _cm_encode_fpath(parent_sym "${parent}")
+    endif()
+    get_filename_component(leaf "${dirpath}" NAME)
+    set_property(
+        TARGET "${name}"
+        APPEND PROPERTY CMRC_MAKE_DIRS
+        "static auto ${sym}_dir = ${parent_sym}_dir.directory.add_subdir(\"${leaf}\")\;"
+        "root_index.emplace(\"${dirpath}\", &${sym}_dir.index_entry)\;"
+        )
+endfunction()
+
+function(cmrc_add_resources name)
+    get_target_property(is_reslib ${name} CMRC_IS_RESOURCE_LIBRARY)
+    if(NOT TARGET ${name} OR NOT is_reslib)
+        message(SEND_ERROR "cmrc_add_resources called on target '${name}' which is not an existing resource library")
+        return()
+    endif()
+
+    set(options)
+    set(args WHENCE PREFIX)
+    set(list_args)
+    cmake_parse_arguments(ARG "${options}" "${args}" "${list_args}" "${ARGN}")
+
+    if(NOT ARG_WHENCE)
+        set(ARG_WHENCE ${CMAKE_CURRENT_SOURCE_DIR})
+    endif()
+    _cmrc_normalize_path(ARG_WHENCE)
+    get_filename_component(ARG_WHENCE "${ARG_WHENCE}" ABSOLUTE)
+
+    # Generate the identifier for the resource library's namespace
+    get_target_property(lib_ns "${name}" CMRC_NAMESPACE)
+
+    get_target_property(libdir ${name} CMRC_LIBDIR)
+    get_target_property(target_dir ${name} SOURCE_DIR)
+    file(RELATIVE_PATH reldir "${target_dir}" "${CMAKE_CURRENT_SOURCE_DIR}")
+    if(reldir MATCHES "^\\.\\.")
+        message(SEND_ERROR "Cannot call cmrc_add_resources in a parent directory from the resource library target")
+        return()
+    endif()
+
+    foreach(input IN LISTS ARG_UNPARSED_ARGUMENTS)
+        _cmrc_normalize_path(input)
+        get_filename_component(abs_in "${input}" ABSOLUTE)
+        # Generate a filename based on the input filename that we can put in
+        # the intermediate directory.
+        file(RELATIVE_PATH relpath "${ARG_WHENCE}" "${abs_in}")
+        if(relpath MATCHES "^\\.\\.")
+            # For now we just error on files that exist outside of the soure dir.
+            message(SEND_ERROR "Cannot add file '${input}': File must be in a subdirectory of ${ARG_WHENCE}")
+            continue()
+        endif()
+        if(DEFINED ARG_PREFIX)
+            _cmrc_normalize_path(ARG_PREFIX)
+        endif()
+        if(ARG_PREFIX AND NOT ARG_PREFIX MATCHES "/$")
+            set(ARG_PREFIX "${ARG_PREFIX}/")
+        endif()
+        get_filename_component(dirpath "${ARG_PREFIX}${relpath}" DIRECTORY)
+        _cmrc_register_dirs("${name}" "${dirpath}")
+        get_filename_component(abs_out "${libdir}/intermediate/${relpath}.cpp" ABSOLUTE)
+        # Generate a symbol name relpath the file's character array
+        _cm_encode_fpath(sym "${relpath}")
+        # Get the symbol name for the parent directory
+        if(dirpath STREQUAL "")
+            set(parent_sym root_directory)
+        else()
+            _cm_encode_fpath(parent_sym "${dirpath}")
+        endif()
+        # Generate the rule for the intermediate source file
+        _cmrc_generate_intermediate_cpp(${lib_ns} ${sym} "${abs_out}" "${abs_in}")
+        target_sources(${name} PRIVATE "${abs_out}")
+        set_property(TARGET ${name} APPEND PROPERTY CMRC_EXTERN_DECLS
+            "// Pointers to ${input}"
+            "extern const char* const ${sym}_begin\;"
+            "extern const char* const ${sym}_end\;"
+            )
+        get_filename_component(leaf "${relpath}" NAME)
+        set_property(
+            TARGET ${name}
+            APPEND PROPERTY CMRC_MAKE_FILES
+            "root_index.emplace("
+            "    \"${ARG_PREFIX}${relpath}\","
+            "    ${parent_sym}_dir.directory.add_file("
+            "        \"${leaf}\","
+            "        res_chars::${sym}_begin,"
+            "        res_chars::${sym}_end"
+            "    )"
+            ")\;"
+            )
+    endforeach()
+endfunction()
+
+function(_cmrc_generate_intermediate_cpp lib_ns symbol outfile infile)
+    add_custom_command(
+        # This is the file we will generate
+        OUTPUT "${outfile}"
+        # These are the primary files that affect the output
+        DEPENDS "${infile}" "${_CMRC_SCRIPT}"
+        COMMAND
+            "${CMAKE_COMMAND}"
+                -D_CMRC_GENERATE_MODE=TRUE
+                -DNAMESPACE=${lib_ns}
+                -DSYMBOL=${symbol}
+                "-DINPUT_FILE=${infile}"
+                "-DOUTPUT_FILE=${outfile}"
+                -P "${_CMRC_SCRIPT}"
+        COMMENT "Generating intermediate file for ${infile}"
+    )
+endfunction()
+
+function(_cm_encode_fpath var fpath)
+    string(MAKE_C_IDENTIFIER "${fpath}" ident)
+    string(MD5 hash "${fpath}")
+    string(SUBSTRING "${hash}" 0 4 hash)
+    set(${var} f_${hash}_${ident} PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
Now that the default profile files are compiled into a library with CMRC, code to access the PLUGIN_RELATIVE_DIR in the .h file is not needed. Also, no need to copy the stain profile XML files to the plugin directory at the install step.